### PR TITLE
chore: unify header button styles

### DIFF
--- a/app/components/CourseActionsDropdown.vue
+++ b/app/components/CourseActionsDropdown.vue
@@ -91,7 +91,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-    <div class="relative">
+    <div ref="popupRef" class="relative">
         <button
             class="flex items-center gap-2 px-3 py-2 border border-(--main-color) text-(--main-color) rounded-sm hover:bg-(--main-color) hover:text-(--bg-color) transition-colors text-sm font-medium focus-outline"
             @click.stop.prevent="popupVisible = !popupVisible"
@@ -112,7 +112,6 @@ onBeforeUnmount(() => {
         <!-- Dropdown -->
         <div
             v-if="popupVisible"
-            ref="popupRef"
             class="absolute top-full mb-2 mt-2 right-0 bg-(--bg-color) border border-(--sub-color) rounded-lg shadow-lg min-w-max max-h-80 z-50 overflow-y-auto"
         >
             <div class="p-2">

--- a/app/components/CourseActionsDropdown.vue
+++ b/app/components/CourseActionsDropdown.vue
@@ -92,37 +92,22 @@ onBeforeUnmount(() => {
 
 <template>
     <div class="relative">
-        <div
-            class="flex items-center gap-2 cursor-pointer focus-outline rounded px-3 py-2 border border-(--main-color) text-(--main-color) hover:bg-(--main-color) hover:text-(--bg-color) transition-colors"
-            tabindex="0"
-            @mousedown.stop.prevent="popupVisible = !popupVisible"
-            @keydown.enter="
-                () => {
-                    popupVisible = !popupVisible;
-                }
-            "
-            @keydown.esc.stop.prevent="
-                () => {
-                    popupVisible = false;
-                }
-            "
-            @keydown.space="
-                () => {
-                    popupVisible = !popupVisible;
-                }
-            "
+        <button
+            class="flex items-center gap-2 px-3 py-2 border border-(--main-color) text-(--main-color) rounded-sm hover:bg-(--main-color) hover:text-(--bg-color) transition-colors text-sm font-medium focus-outline"
+            @click.stop.prevent="popupVisible = !popupVisible"
+            @keydown.enter.prevent="popupVisible = !popupVisible"
+            @keydown.esc.stop.prevent="popupVisible = false"
+            @keydown.space.prevent="popupVisible = !popupVisible"
         >
-            <div class="flex items-center gap-1">
-                <div class="text-sm font-medium">Menu</div>
-                <Icon
-                    name="lucide:chevron-up"
-                    :class="[
-                        'cursor-pointer hover:opacity-80 transition-transform',
-                        popupVisible ? 'rotate-0' : 'rotate-180',
-                    ]"
-                />
-            </div>
-        </div>
+            <span>Menu</span>
+            <Icon
+                name="lucide:chevron-up"
+                :class="[
+                    'h-4 w-4 scale-125 -translate-y-0.25 transition-transform',
+                    popupVisible ? 'rotate-0' : 'rotate-180',
+                ]"
+            />
+        </button>
 
         <!-- Dropdown -->
         <div

--- a/app/components/CourseActionsDropdown.vue
+++ b/app/components/CourseActionsDropdown.vue
@@ -103,7 +103,7 @@ onBeforeUnmount(() => {
             <Icon
                 name="lucide:chevron-up"
                 :class="[
-                    'h-4 w-4 scale-125 -translate-y-0.25 transition-transform',
+                    'h-4 w-4 scale-150 transition-transform',
                     popupVisible ? 'rotate-0' : 'rotate-180',
                 ]"
             />

--- a/app/components/PlanSelector.vue
+++ b/app/components/PlanSelector.vue
@@ -103,10 +103,7 @@ onBeforeUnmount(() => {
             class="flex items-center gap-2 px-3 py-2 border border-(--main-color) text-(--main-color) rounded-sm hover:bg-(--main-color) hover:text-(--bg-color) transition-colors text-sm font-medium"
             @click="addPlan"
         >
-            <Icon
-                name="lucide:plus"
-                class="h-4 w-4 scale-125 -translate-y-0.25"
-            />
+            <Icon name="lucide:plus" class="h-4 w-4 scale-125" />
             Add Plan
         </button>
 
@@ -116,17 +113,14 @@ onBeforeUnmount(() => {
                 class="flex items-center gap-2 px-3 py-2 border border-(--main-color) text-(--main-color) rounded-sm hover:bg-(--main-color) hover:text-(--bg-color) transition-colors text-sm font-medium"
                 @click="dropdownOpen = !dropdownOpen"
             >
-                <Icon
-                    name="lucide:clipboard-list"
-                    class="h-4 w-4 scale-125 -translate-y-0.25"
-                />
+                <Icon name="lucide:clipboard-list" class="h-4 w-4 scale-125" />
                 <span class="font-medium">
                     {{ currentPlan ? currentPlan.name : "Select Plan" }}
                 </span>
                 <Icon
                     name="lucide:chevron-down"
                     :class="[
-                        'h-4 w-4 transition-transform',
+                        'h-4 w-4 transition-transform scale-150',
                         dropdownOpen ? 'rotate-180' : 'rotate-0',
                     ]"
                 />

--- a/app/components/PlanSelector.vue
+++ b/app/components/PlanSelector.vue
@@ -113,7 +113,7 @@ onBeforeUnmount(() => {
         <!-- Plan Selector Dropdown (only show if there are plans) -->
         <div v-if="plans.length > 0" ref="dropdownRef" class="relative">
             <button
-                class="flex items-center gap-2 px-3 py-2 border border-(--sub-color) rounded-sm bg-(--bg-color) text-(--main-color) hover:bg-(--sub-color)/10 transition-colors text-sm"
+                class="flex items-center gap-2 px-3 py-2 border border-(--main-color) text-(--main-color) rounded-sm hover:bg-(--main-color) hover:text-(--bg-color) transition-colors text-sm font-medium"
                 @click="dropdownOpen = !dropdownOpen"
             >
                 <Icon


### PR DESCRIPTION
## Summary
- standardize course header menu button to match other controls
- apply consistent color scheme to plan selector

## Testing
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b66ccdca30832f87e132c4485c2de4