### PR TITLE
feat: add dashboard for recent courses and plans

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -12,7 +12,7 @@ definePageMeta({
 });
 
 useHead({
-    title: "Home",
+    title: "shpacer",
 });
 
 interface PlanWithCourse extends SelectPlan {
@@ -37,11 +37,11 @@ const {
     data: plansData,
     pending: plansPending,
     error: plansError,
-} = await useFetch<PlanListResponse>("/api/plans?limit=5");
+} = await useFetch<PlanListResponse>("/api/plans?limit=4");
 
 const userSettingsStore = useUserSettingsStore();
 
-const courses = computed(() => (coursesData.value?.courses ?? []).slice(0, 5));
+const courses = computed(() => (coursesData.value?.courses ?? []).slice(0, 4));
 const plans = computed(() => plansData.value?.plans ?? []);
 
 function formatCourseDistance(meters: number) {
@@ -65,8 +65,12 @@ function formatPace(pace: number, paceUnit: string) {
     <div class="flex flex-col w-full h-full overflow-hidden">
         <AppHeader class="w-full" />
         <div class="w-full h-full p-4 flex flex-col gap-6 overflow-auto">
-            <h2 class="text-2xl font-bold text-(--main-color)">Dashboard</h2>
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div
+                class="text-6xl font-bold text-(--main-color) logo text-center"
+            >
+                shpacer
+            </div>
+            <div class="flex flex-col gap-6">
                 <!-- Recent Courses -->
                 <div>
                     <h3 class="text-xl font-semibold text-(--main-color) mb-2">
@@ -93,14 +97,12 @@ function formatPace(pace: number, paceUnit: string) {
                     >
                         No courses yet
                     </div>
-                    <div
-                        v-else
-                        class="grid grid-cols-1 md:grid-cols-2 gap-4"
-                    >
+                    <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div
                             v-for="course in courses"
                             :key="course.id"
-                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4"
+                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4 hover:border-(--main-color) transition-colors group cursor-pointer"
+                            @click="$router.push(`/courses/${course.id}`)"
                         >
                             <h4
                                 class="font-semibold text-(--main-color) truncate"
@@ -142,6 +144,22 @@ function formatPace(pace: number, paceUnit: string) {
                                         }}
                                     </span>
                                 </div>
+                                <div
+                                    v-if="course.elevationLoss"
+                                    class="flex items-center gap-1"
+                                >
+                                    <Icon
+                                        name="lucide:arrow-down"
+                                        class="h-3 w-3 -translate-y-0.25"
+                                    />
+                                    <span>
+                                        {{
+                                            formatCourseElevation(
+                                                course.elevationLoss,
+                                            )
+                                        }}
+                                    </span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -173,25 +191,27 @@ function formatPace(pace: number, paceUnit: string) {
                     >
                         No plans yet
                     </div>
-                    <div
-                        v-else
-                        class="grid grid-cols-1 md:grid-cols-2 gap-4"
-                    >
+                    <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-4">
                         <div
                             v-for="plan in plans"
                             :key="plan.id"
-                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4"
+                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4 hover:border-(--main-color) transition-colors group cursor-pointer"
+                            @click="
+                                $router.push(
+                                    `/courses/${plan.courseId}?plan=${plan.id}`,
+                                )
+                            "
                         >
+                            <div
+                                class="text-(--main-color) font-semibold truncate mb-1"
+                            >
+                                {{ plan.courseName }}
+                            </div>
                             <h4
-                                class="font-semibold text-(--main-color) truncate"
+                                class="font-medium text-(--main-color) truncate"
                             >
                                 {{ plan.name }}
                             </h4>
-                            <p
-                                class="text-xs text-(--sub-color) mb-2 truncate"
-                            >
-                                {{ plan.courseName }}
-                            </p>
                             <div
                                 class="flex items-center gap-3 text-xs text-(--main-color)"
                             >
@@ -203,7 +223,9 @@ function formatPace(pace: number, paceUnit: string) {
                                         name="lucide:gauge"
                                         class="h-3 w-3 -translate-y-0.25"
                                     />
-                                    <span>{{ formatPace(plan.pace, plan.paceUnit) }}</span>
+                                    <span>{{
+                                        formatPace(plan.pace, plan.paceUnit)
+                                    }}</span>
                                 </div>
                                 <div
                                     v-if="plan.targetTimeSeconds"
@@ -213,7 +235,11 @@ function formatPace(pace: number, paceUnit: string) {
                                         name="lucide:timer"
                                         class="h-3 w-3 -translate-y-0.25"
                                     />
-                                    <span>{{ formatElapsedTime(plan.targetTimeSeconds) }}</span>
+                                    <span>{{
+                                        formatElapsedTime(
+                                            plan.targetTimeSeconds,
+                                        )
+                                    }}</span>
                                 </div>
                             </div>
                         </div>
@@ -223,3 +249,9 @@ function formatPace(pace: number, paceUnit: string) {
         </div>
     </div>
 </template>
+
+<style>
+.logo {
+    font-family: Poppins, sans-serif;
+}
+</style>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,4 +1,9 @@
 <script setup lang="ts">
+import type { SelectCourse, SelectPlan } from "~/utils/db/schema";
+import { formatDistance, formatElevation } from "~/utils/courseMetrics";
+import { formatElapsedTime } from "~/utils/timeCalculations";
+import { useUserSettingsStore } from "~/stores/userSettings";
+
 definePageMeta({
     auth: {
         only: "user",
@@ -6,18 +11,214 @@ definePageMeta({
     },
 });
 
-// Page metadata
 useHead({
     title: "Home",
 });
+
+interface PlanWithCourse extends SelectPlan {
+    courseName: string;
+}
+
+interface CourseListResponse {
+    courses: Omit<SelectCourse, "originalFileContent" | "geoJsonData">[];
+}
+
+interface PlanListResponse {
+    plans: PlanWithCourse[];
+}
+
+const {
+    data: coursesData,
+    pending: coursesPending,
+    error: coursesError,
+} = await useFetch<CourseListResponse>("/api/courses");
+
+const {
+    data: plansData,
+    pending: plansPending,
+    error: plansError,
+} = await useFetch<PlanListResponse>("/api/plans?limit=5");
+
+const userSettingsStore = useUserSettingsStore();
+
+const courses = computed(() => (coursesData.value?.courses ?? []).slice(0, 5));
+const plans = computed(() => plansData.value?.plans ?? []);
+
+function formatCourseDistance(meters: number) {
+    return formatDistance(meters, userSettingsStore.settings.units.distance);
+}
+
+function formatCourseElevation(meters: number) {
+    return formatElevation(meters, userSettingsStore.settings.units.elevation);
+}
+
+function formatPace(pace: number, paceUnit: string) {
+    const totalSeconds = Math.round(pace);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const unit = paceUnit === "min_per_mi" ? "/mi" : "/km";
+    return `${minutes}:${seconds.toString().padStart(2, "0")} ${unit}`;
+}
 </script>
 
 <template>
     <div class="flex flex-col w-full h-full overflow-hidden">
         <AppHeader class="w-full" />
-        <div class="w-full h-full p-4 flex flex-col gap-4">
-            <div>
-                <h2 class="text-2xl font-bold mb-2">shpacer</h2>
+        <div class="w-full h-full p-4 flex flex-col gap-6 overflow-auto">
+            <h2 class="text-2xl font-bold text-(--main-color)">Dashboard</h2>
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <!-- Recent Courses -->
+                <div>
+                    <h3 class="text-xl font-semibold text-(--main-color) mb-2">
+                        Recent Courses
+                    </h3>
+                    <div
+                        v-if="coursesPending"
+                        class="flex items-center justify-center py-8"
+                    >
+                        <Icon
+                            name="svg-spinners:6-dots-scale"
+                            class="text-(--main-color) scale-200"
+                        />
+                    </div>
+                    <div
+                        v-else-if="coursesError"
+                        class="text-(--error-color) py-8 text-center"
+                    >
+                        Failed to load courses
+                    </div>
+                    <div
+                        v-else-if="courses.length === 0"
+                        class="text-(--sub-color) py-8 text-center"
+                    >
+                        No courses yet
+                    </div>
+                    <div
+                        v-else
+                        class="grid grid-cols-1 md:grid-cols-2 gap-4"
+                    >
+                        <div
+                            v-for="course in courses"
+                            :key="course.id"
+                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4"
+                        >
+                            <h4
+                                class="font-semibold text-(--main-color) truncate"
+                            >
+                                {{ course.name }}
+                            </h4>
+                            <div
+                                class="flex items-center gap-3 mt-2 text-xs text-(--main-color)"
+                            >
+                                <div
+                                    v-if="course.totalDistance"
+                                    class="flex items-center gap-1"
+                                >
+                                    <Icon
+                                        name="lucide:move-horizontal"
+                                        class="h-3 w-3 -translate-y-0.25"
+                                    />
+                                    <span>
+                                        {{
+                                            formatCourseDistance(
+                                                course.totalDistance,
+                                            )
+                                        }}
+                                    </span>
+                                </div>
+                                <div
+                                    v-if="course.elevationGain"
+                                    class="flex items-center gap-1"
+                                >
+                                    <Icon
+                                        name="lucide:arrow-up"
+                                        class="h-3 w-3 -translate-y-0.25"
+                                    />
+                                    <span>
+                                        {{
+                                            formatCourseElevation(
+                                                course.elevationGain,
+                                            )
+                                        }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Recent Plans -->
+                <div>
+                    <h3 class="text-xl font-semibold text-(--main-color) mb-2">
+                        Recent Plans
+                    </h3>
+                    <div
+                        v-if="plansPending"
+                        class="flex items-center justify-center py-8"
+                    >
+                        <Icon
+                            name="svg-spinners:6-dots-scale"
+                            class="text-(--main-color) scale-200"
+                        />
+                    </div>
+                    <div
+                        v-else-if="plansError"
+                        class="text-(--error-color) py-8 text-center"
+                    >
+                        Failed to load plans
+                    </div>
+                    <div
+                        v-else-if="plans.length === 0"
+                        class="text-(--sub-color) py-8 text-center"
+                    >
+                        No plans yet
+                    </div>
+                    <div
+                        v-else
+                        class="grid grid-cols-1 md:grid-cols-2 gap-4"
+                    >
+                        <div
+                            v-for="plan in plans"
+                            :key="plan.id"
+                            class="bg-(--sub-alt-color) border border-(--sub-color) rounded-lg p-4"
+                        >
+                            <h4
+                                class="font-semibold text-(--main-color) truncate"
+                            >
+                                {{ plan.name }}
+                            </h4>
+                            <p
+                                class="text-xs text-(--sub-color) mb-2 truncate"
+                            >
+                                {{ plan.courseName }}
+                            </p>
+                            <div
+                                class="flex items-center gap-3 text-xs text-(--main-color)"
+                            >
+                                <div
+                                    v-if="plan.pace"
+                                    class="flex items-center gap-1"
+                                >
+                                    <Icon
+                                        name="lucide:gauge"
+                                        class="h-3 w-3 -translate-y-0.25"
+                                    />
+                                    <span>{{ formatPace(plan.pace, plan.paceUnit) }}</span>
+                                </div>
+                                <div
+                                    v-if="plan.targetTimeSeconds"
+                                    class="flex items-center gap-1"
+                                >
+                                    <Icon
+                                        name="lucide:timer"
+                                        class="h-3 w-3 -translate-y-0.25"
+                                    />
+                                    <span>{{ formatElapsedTime(plan.targetTimeSeconds) }}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/server/api/plans/index.get.ts
+++ b/server/api/plans/index.get.ts
@@ -1,0 +1,48 @@
+import { plans, courses } from "~/utils/db/schema";
+import { cloudDb } from "~~/server/utils/db/cloud";
+import { eq, desc } from "drizzle-orm";
+import { auth } from "~/utils/auth";
+
+export default defineEventHandler(async (event) => {
+  const session = await auth.api.getSession({
+    headers: event.headers,
+  });
+
+  if (!session?.user?.id) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: "Unauthorized",
+    });
+  }
+
+  const query = getQuery(event);
+  const limit =
+    typeof query.limit === "string" ? parseInt(query.limit, 10) : 5;
+
+  try {
+    const userPlans = await cloudDb
+      .select({
+        id: plans.id,
+        name: plans.name,
+        courseId: plans.courseId,
+        pace: plans.pace,
+        paceUnit: plans.paceUnit,
+        targetTimeSeconds: plans.targetTimeSeconds,
+        createdAt: plans.createdAt,
+        courseName: courses.name,
+      })
+      .from(plans)
+      .innerJoin(courses, eq(plans.courseId, courses.id))
+      .where(eq(plans.userId, session.user.id))
+      .orderBy(desc(plans.createdAt))
+      .limit(limit);
+
+    return { plans: userPlans };
+  } catch (error) {
+    console.error("Error fetching plans:", error);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to fetch plans",
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add API to fetch recent plans with course info
- show recent courses and plans on home dashboard

## Testing
- `pnpm run lint` *(fails: Missing script: lint)*
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b66d568148832f8c0aea62eed8de6b